### PR TITLE
Add alpha support

### DIFF
--- a/grovel.lisp
+++ b/grovel.lisp
@@ -9,6 +9,7 @@
 (constant (+png-color-mask-alpha+ "PNG_COLOR_MASK_ALPHA"))
 (constant (+png-color-type-palette+ "PNG_COLOR_TYPE_PALETTE"))
 (constant (+png-color-type-rgb+ "PNG_COLOR_TYPE_RGB"))
+(constant (+png-color-type-rgb-alpha+ "PNG_COLOR_TYPE_RGB_ALPHA"))
 (constant (+png-color-type-gray+ "PNG_COLOR_TYPE_GRAY"))
 (constant (+png-color-type-gray-alpha+ "PNG_COLOR_TYPE_GRAY_ALPHA"))
 (constant (+png-transform-strip-16+ "PNG_TRANSFORM_STRIP_16"))

--- a/libpng.lisp
+++ b/libpng.lisp
@@ -340,9 +340,11 @@ Signals an error if writing the image fails."
 			  (callback user-flush-data))
 	(png-set-ihdr png-ptr info-ptr (image-width image) (image-height image)
 		      (image-bit-depth image)
-		      (if (= (image-channels image) 1)
-			  +png-color-type-gray+
-			  +png-color-type-rgb+)
+                      (ecase (image-channels image)
+                        (1 +png-color-type-gray+)
+                        (2 +png-color-type-gray-alpha+)
+                        (3 +png-color-type-rgb+)
+                        (4 +png-color-type-rgb-alpha+))
 		      +png-interlace-none+ +png-compression-type-default+
 		      +png-filter-type-default+)
 	(when swapBGR


### PR DESCRIPTION
Well cl-png was faster than one of the other png writing libraries I tried, so I have been using a hacked version of it in the backend of http://canadarasp.com for the last few years, finally pushing the minor changes back.