### PR TITLE
Support tRNS chunk for alpha, add msys2 dll name on window

### DIFF
--- a/grovel.lisp
+++ b/grovel.lisp
@@ -21,6 +21,7 @@
 (constant (+png-filter-type-default+ "PNG_FILTER_TYPE_DEFAULT"))
 (constant (+png-transform-identity+ "PNG_TRANSFORM_IDENTITY"))
 (constant (+png-interlace-none+ "PNG_INTERLACE_NONE"))
+(constant (+png-info-trns+ "PNG_INFO_tRNS"))
 (ctype ssize "ssize_t")
 (ctype size "size_t")
 (ctype png-size "png_size_t")

--- a/libpng.lisp
+++ b/libpng.lisp
@@ -304,13 +304,21 @@ Signals an error if reading the image fails."
 	    (when (= bit-depth 16)
 	      (png-set-swap png-ptr))
 	    (unless (or preserve-alpha
-			(zerop (logand color-type +png-color-mask-alpha+)))
+			(and (zerop (logand color-type +png-color-mask-alpha+))
+                             (zerop (png-get-valid png-ptr info-ptr +png-info-trns+))))
 	      (png-set-strip-alpha png-ptr))
+            (when (and preserve-alpha
+                       (plusp (png-get-valid png-ptr info-ptr +png-info-trns+)))
+              (png-set-trns-to-alpha png-ptr))
+
         (when swapBGR
           (png-set-bgr png-ptr))
-	(let* ((alphas (if (and preserve-alpha
-				(plusp (logand color-type
-					       +png-color-mask-alpha+)))
+	    (let* ((alphas (if (and preserve-alpha
+				    (or (plusp (logand color-type
+                                                       +png-color-mask-alpha+))
+                                        (plusp
+                                         (png-get-valid png-ptr info-ptr
+                                                        +png-info-trns+))))
 			   1 0))
 	       (image (make-image height width
 				  (+ (if (grayp color-type) 1 3) alphas)

--- a/libpng.lisp
+++ b/libpng.lisp
@@ -8,6 +8,7 @@
 
 (define-foreign-library libpng
   (:darwin "libpng.dylib")
+  (:windows (:or "libpng.dll" "libpng16-16.dll"))
   (t (:default "libpng")))
 
 (use-foreign-library libpng)


### PR DESCRIPTION
Turning on expansion of palettes (and possibly some other things?) also expands `tRNS` chunks to alpha, so if we don't handle those correctly we will get memory corruption when we expect 3 bytes per pixel but libpng thinks we want 4.